### PR TITLE
[BUG] Fix YAML - JSON Convertor #2 - solved

### DIFF
--- a/yaml-json-converter.html
+++ b/yaml-json-converter.html
@@ -190,18 +190,24 @@ skills:
                 yamlToJsonBtn.classList.add('bg-slate-600');
             });
 
-            function updateUI() {
-                if (conversionMode === 'yaml-to-json') {
-                    inputLabel.textContent = 'YAML Input';
-                    outputLabel.textContent = 'JSON Output';
-                    inputText.placeholder = 'Paste your YAML data here...';
-                } else {
-                    inputLabel.textContent = 'JSON Input';
-                    outputLabel.textContent = 'YAML Output';
-                    inputText.placeholder = 'Paste your JSON data here...';
-                }
-                hideOutput();
-                hideError();
+           function updateUI() {
+    if (conversionMode === 'yaml-to-json') {
+        inputLabel.textContent = 'YAML Input';
+        outputLabel.textContent = 'JSON Output';
+        inputText.placeholder = 'Paste your YAML data here...';
+    } else {
+        inputLabel.textContent = 'JSON Input';
+        outputLabel.textContent = 'YAML Output';
+        inputText.placeholder = 'Paste your JSON data here...';
+    }
+
+    // If there is previous conversion output, move it into the input so users can flip conversion quickly
+    if (!outputSection.classList.contains('hidden') && outputText.value.trim()) {
+        inputText.value = outputText.value;
+    }
+
+    hideOutput();
+    hideError();
             }
 
             // Convert


### PR DESCRIPTION
Type of change - Bug 
1 change 
problem - [BUG] Fix YAML - JSON Convertor #2
Open

solved a bug - 
changes - conversion of yaml to json was working but when we hit json to yml it was not taking json input we have created and not converting to yml 
I solved this and now the converted part of json is saved and acting as an input at the time of json to yml conversion and it is working as expected.

Tested on chrome 

before - 
<img width="3045" height="2060" alt="Screenshot (178)" src="https://github.com/user-attachments/assets/14d5b335-c9e2-483c-ba2b-8a66e1a5bbe9" />
after - 
<img width="3840" height="2067" alt="Screenshot (177)" src="https://github.com/user-attachments/assets/73835d37-8a57-4d2a-a8a1-9e0f79a4b176" />

