### PR TITLE
fix: make sidebar hamburger functional on mobile (#4)

### DIFF
--- a/final_sidebar.html
+++ b/final_sidebar.html
@@ -353,7 +353,7 @@
 
 <!-- Mobile Sidebar Toggle -->
 <div class="lg:hidden fixed top-4 left-4 z-[60]">
-    <button id="mobile-sidebar-toggle" class="p-3 bg-slate-800/95 backdrop-blur-md border border-slate-700/60 rounded-lg text-white hover:bg-slate-700/90 transition-colors duration-200 shadow-lg" style="pointer-events: auto;">
+    <button id="mobile-sidebar-toggle" class="p-3 bg-slate-800/95 backdrop-blur-md border border-slate-700/60 rounded-lg text-white hover:bg-slate-700/90 transition-colors duration-200 shadow-lg" style="pointer-events: auto;" onclick="(function(){var s=document.getElementById('sidebar');var o=document.getElementById('mobile-sidebar-overlay');if(!s)return;var isOpen=!s.classList.contains('-translate-x-full');if(isOpen){s.classList.add('-translate-x-full');if(o)o.classList.add('hidden');document.body.style.overflow='';this.setAttribute('aria-expanded','false');if(s)s.setAttribute('aria-hidden','true');}else{s.classList.remove('-translate-x-full');if(o)o.classList.remove('hidden');document.body.style.overflow='hidden';this.setAttribute('aria-expanded','true');if(s)s.setAttribute('aria-hidden','false');}})()">
         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
         </svg>
@@ -361,7 +361,7 @@
 </div>
 
 <!-- Mobile Sidebar Overlay -->
-<div id="mobile-sidebar-overlay" class="lg:hidden fixed inset-0 bg-black/50 backdrop-blur-sm z-40 hidden"></div>
+<div id="mobile-sidebar-overlay" class="lg:hidden fixed inset-0 bg-black/50 backdrop-blur-sm z-40 hidden" onclick="(function(){var s=document.getElementById('sidebar');var o=document.getElementById('mobile-sidebar-overlay');if(s)s.classList.add('-translate-x-full');if(o)o.classList.add('hidden');document.body.style.overflow='';})()"></div>
 
 <script>
 // Initialize sidebar functionality

--- a/navbar.html
+++ b/navbar.html
@@ -3,7 +3,7 @@
     <div class="container mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex items-center justify-between h-16">
             <!-- Mobile Menu Button -->
-            <button id="sidebar-toggle" class="p-2 rounded-lg text-gray-400 hover:text-white hover:bg-slate-800 transition-colors md:hidden">
+            <button id="sidebar-toggle" class="p-2 rounded-lg text-gray-400 hover:text-white hover:bg-slate-800 transition-colors md:hidden" onclick="(function(){var s=document.getElementById('sidebar');var o=document.getElementById('mobile-sidebar-overlay');if(!s)return;var isOpen=!s.classList.contains('-translate-x-full');if(isOpen){s.classList.add('-translate-x-full');if(o)o.classList.add('hidden');document.body.style.overflow='';this.setAttribute('aria-expanded','false');if(s)s.setAttribute('aria-hidden','true');}else{s.classList.remove('-translate-x-full');if(o)o.classList.remove('hidden');document.body.style.overflow='hidden';this.setAttribute('aria-expanded','true');if(s)s.setAttribute('aria-hidden','false');}})()">
                 <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
                 </svg>


### PR DESCRIPTION
## 📝 Description
Fixes the mobile hamburger not toggling the sidebar.  
The `final_sidebar.html` script was not executing because it’s injected via `innerHTML`.  
Added minimal inline click handlers for the sidebar and navbar toggles — now works on mobile without affecting desktop.

## 🎯 Type of Change
- [x] 🐛 Bug fix
- [x] 🎨 UI/UX improvement

## 🛠️ Changes Made
- Added mobile toggle handler to `navbar.html`.
- Added inline click/overlay logic in `final_sidebar.html`.
- Sidebar now slides in/out correctly on mobile (`transform` + overlay).
- Ensured desktop (`lg:`) behavior unchanged.

## 🧪 Testing
- [x] ✅ Tested on Chrome
- [x] ✅ Tested on Firefox
- [x] ✅ Tested on Edge
- [x] ✅ Tested on mobile devices
- [x] ✅ No console errors
- [x] ✅ Responsive design works properly

## 📸 Screenshots

### Before
Sidebar hamburger did nothing on mobile.

### After
Sidebar now toggles smoothly on mobile; overlay click closes it.
<img width="612" height="882" alt="image" src="https://github.com/user-attachments/assets/f7b9af4c-4f02-4fb8-bfda-3caf0e2776e2" />

## 🔗 Related Issues
Fixes #4

## 📋 Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] New and existing pages remain responsive

## 🎯 Additional Notes
This PR touches only two files (`navbar.html` and `final_sidebar.html`) to ensure minimal diff and avoid mass refactoring across 50+ tool pages.

## 🙏 Thank You
Thank you for maintaining DevDunia! Excited for my first contribution 🚀
